### PR TITLE
在 Windows 中字体不再使用 editor.fontFamily 并添加合适的字体退回

### DIFF
--- a/tools/settings.coffee
+++ b/tools/settings.coffee
@@ -154,12 +154,7 @@ Settings =
 
       # Font
       if process.platform is 'win32'
-        font = atom.config.get('editor.fontFamily')
-        if font
-          sv.style["fontFamily"] = font
-        else
-          sv.style["fontFamily"] = "'Segoe UI', Microsoft Yahei"
-          sv.style["fontSize"] = "12px"
+        sv.style["fontFamily"] = 'Segoe UI, Microsoft Yahei, sans-serif'
 
       # Load all settings panels
       lastMenu = sv.querySelector('.panels-menu .active a')


### PR DESCRIPTION
* 不再使用 `editor.fontFamily` 作为设置面板字体. ( 界面不宜使用等宽的字体 )
* 缺少 `sans-serif` 会导致 Microsoft Yahei 没有的字体不能显示.
* 固定的字体大小, 会影响 Atom 的字体 Responsive.